### PR TITLE
[3주차] 스프링 핵심 원리 기본편 정리

### DIFF
--- a/스프링_핵심_원리_기본편/Section4_스프링_컨테이너와_스프링_빈/김보현.md
+++ b/스프링_핵심_원리_기본편/Section4_스프링_컨테이너와_스프링_빈/김보현.md
@@ -1,0 +1,161 @@
+## 스프링 컨테이너 생성
+
+```java
+ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
+```
+
+- ApplicationContext를 **스프링 컨테이너**라고 함
+  - ApplicationContext는 인터페이스여서 Annotation기반으로 만들수도 있고 xml기반으로 만들수도 있음
+
+### 스프링 컨테이너 생성과정
+
+1. AppConfig.class(구성정보)를 넘겨서 스프링 컨테이너 생성 => 스프링 컨테이너 안에 스프링 빈 저장소도 같이 생김
+2. 스프링 빈 저장소에 스프링 빈 등록 (@Bean Annotation이 붙은 함수들을 모두 호출)
+   1. Bean의 이름은 항상 다른 이름을 부여해야 함
+3. 스프링 빈 의존관계 설정
+   1. 스프링 컨테이너는 설정 정보를 참고해서 의존관계를 주입(DI)함
+
+### 내가 등록한 빈 확인
+
+```java
+AnnotaionConfigApplicationContext ac = new AnnotationConfigApplicationContext(App.config.class);
+
+String[] beanDefinitaionNames = ac.getBeanDefinititionNames();
+
+for(String beanDefinitionNames : beanDefinitionNames){
+  BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinition);
+
+  if(beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION){
+    Object bean = ac.getBean(beanDefinitionName);
+    System.out.println("beanDefinitionName = " + beanDefinitionName);
+  }
+}
+```
+
+ROLE_APPLICATION : 일반적으로 사용자가 정의한 빈
+ROLE_INFRASTRUCTURE : 스프링이 내부에서 사용하는 빈
+
+### 스프링 빈 조회 방법
+
+#### ac.getBean(빈이름, 타입)
+
+```java
+  @Test
+  @DisplayName("빈 이름으로 조회")
+  void findBeanByName() {
+      MemberService memberService = ac.getBean("memberService", MemberService.class);
+      assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+  }
+```
+
+#### ac.getBean(타입)
+
+```java
+  @Test
+  @DisplayName("이름 없이 타입으로만 조회")
+  void findBeanByType() {
+      MemberService memberService = ac.getBean(MemberService.class);
+      assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+  }
+```
+
+#### 동일한 타입이 둘 이상일 경우
+
+##### 특정 타임을 모두 조회하는 방법
+
+```java
+@Test
+@DisplayName("특정 타입을 모두 조회하기")
+void findAllBeanByType(){
+      Map<String, MemberRepository> beansOfType = ac.getBeansOfType(MemberRepository.class);
+      for (String key : beansOfType.keySet()) {
+          System.out.println("key = " + key + "value = " + beansOfType.get(key));
+      }
+      System.out.println("beansOfType = " + beansOfType);
+      assertThat(beansOfType.size()).isEqualTo(2);
+  }
+```
+
+- 스프링 빈 저장소에 해당 빈이 없으면 예외발생
+
+### 상속관계일 경우 스프링 빈 조회
+
+> 부모 타임으로 조회하면, 자식 타입도 합께 조회된다.
+
+따라서 최고 부모인 "Object"로 조회하면, 모든 스프링 빈을 조회한다.
+
+```java
+  @Test
+  @DisplayName("부모 타입으로 모두 조회하기 - Object")
+  void findAllBeanByObjectType(){
+      Map<String, Object> beansOfType = ac.getBeansOfType(Object.class);
+      for (String key : beansOfType.keySet()) {
+          System.out.println("key = " + key);
+      }
+  }
+```
+
+다음과 같이 조회하면 스프링 빈 저장소에 등록된 모든 빈들이 조회된다.
+
+## BeanFactory와 ApplicationContext
+
+### BeanFactory
+
+> 스프링 컨테이너의 최상위 인터페이스
+
+- 스프링 빈을 관리하고 조회하는 역할을 담당한다.
+
+### ApplicationContext
+
+> BeanFactory + 부가 기능
+
+- MessageSource - i11y. 기능. 제공
+- EnvironmentCapable - 로컬, 개발, 운영등을 구분해서 처리
+- ApplicationEventPublisher - 이벤트를 발행하고 구독하는 모델을 편리하게 지원
+- ResourceLoader - 파일, 클래스패스, 외부 등에서 리소스를 편리하게 조회
+
+beanFactory를 직접 사용할 일은 거의 없다.
+
+beanFactory나 applicationContext를 스프링 컨테이너라 한다.
+
+## XML로 설정
+
+> GenericXmlApplicationContext를 사용하면 됨
+
+- 많은 레거시 프로젝트들이 XML로 되어있음
+- XML을 사용하면 컴파일 없이 빈 설정 정보를 변경할 수 있음
+
+```java
+GenericApplicationContext genericApplicationContext = new GenericXmlApplicationContext("appConfig.xml");
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="memberService" class="hello.core.member.MemberServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository"/>
+    </bean>
+    <bean id="memberRepository" class="hello.core.member.MemoryMemberRepository"/>
+    <bean id="discountPolicy" class="hello.core.discount.RateDiscountPolicy"/>
+    <bean id="orderService" class="hello.core.order.OrderServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository"/>
+        <constructor-arg name="discountPolicy" ref="discountPolicy"/>
+    </bean>
+</beans>
+```
+
+자바코드와 거의 비슷하다.
+
+## 스프링 빈 설정 메타 정보 - BeanDefinition
+
+> 스프링은 Annotation 기반, xml 기반, 등등 어떻게 다양한 설정 형식을 지원할까?
+
+바로 **BeanDefinition**이라는 추상화가 중심이 된다.
+
+BeanDefinition => 빈 설정 메타정보라 한다.
+
+@bean, <bean> 하나당 각각 메타 정보가 생성된다. 스프링 컨테이너는 이 메타정보를 기반으로 스프링 컨테이너를 생성한다.
+
+ApplicationContext의 구현체는 BeanDefinitionReader를 사용해서 설정정보를 읽고 BeanDefinition을 생성한다.

--- a/스프링_핵심_원리_기본편/Section5_싱글톤_컨테이너/김보현.md
+++ b/스프링_핵심_원리_기본편/Section5_싱글톤_컨테이너/김보현.md
@@ -1,0 +1,128 @@
+## 싱글톤 패턴의 필요성
+
+- 스프링은 기업용 온라인 서비스 기술을 지원하기 위해 탄생함
+- 웹 어플리케이션은 보통 여러 고객이 동시에 요청함
+- 우리가 만들었던 스프링 없는 DI 컨테이너는 요청을 할때마다 객체를 새로 생성함
+- 이는 낭비가 심하니 1개의 객체를 생성해 돌려쓸 수 있는 싱글톤 패턴이 필요
+
+## 싱글톤 패턴
+
+> 클래스의 인스턴스가 1개만 생성되는 것을 보장하는 디자인 패턴
+
+스프링 컨테이너를 쓰면 기본적으로 객체를 싱글톤으로 만들어서 관리해준다.
+
+```java
+  @Test
+  @DisplayName("싱글톤 패턴을 적용한 객체 사용")
+  void singletonServiceTest(){
+      SingletonService instance1 = SingletonService.getInstance();
+      SingletonService instance2 = SingletonService.getInstance();
+
+      System.out.println("instance1 = " + instance1);
+      System.out.println("instance2 = " + instance2);
+
+      Assertions.assertThat(instance1).isSameAs(instance2);
+  }
+```
+
+호출마다 같은 인스턴스를 반환한다.
+
+#### 문제점
+
+- 구현코드가 늘어난다.
+- 클라이언트가 구체 클래스에 의존하여 DIP를 위반한다.
+- 클라이언트가 구체 클래서에 의존하여 OCP 원칙을 위반할 가능성이 높다.
+- 테스트하기 어렵다.
+- 내부 속성을 변경하거나 초기화하기 어렵다.
+- private 생성자로 자식 클래스를 만들기 어렵다.
+- 유연성이 떨어진다.
+
+## 싱글톤 컨테이너 (스프링 컨테이너)
+
+> 스프링 컨테이너는 싱글톤 패턴의 문제점을 해결하면서 객체를 싱글톤으로 관리한다.
+
+스프링 빈 => 싱글톤으로 관리되는 빈
+
+- 스프링 컨테이너는 싱글톤 컨테이너 역할을 한다. 이렇게 싱글톤 객체를 생성하고 관리하는 기능을 싱글톤 레지스트리라 한다.
+- 스프링 컨테이너는 싱글톤 패턴의 모든 단점을 해결하면서 객체를 싱글톤으로 유지할 수 있다.
+  - 싱글톤 패턴을 위한 지저분한 코드가 들어가지 않아도 된다.
+  - DIP, OCP, 테스트, private 생성자로 부터 자유롭게 싱글톤을 사용할 수 있다.
+
+요청할때마다 새로운 객체를 생성해서 반환하는 기능도 제공함
+
+## 싱글톤 방식의 주의점
+
+싱글톤은 여러 클라이언트가 하나의 같은 객체 인스턴스를 공유하기 때문에 상태를 유지(Stateful)하게 설계하면 안됨
+
+- 특정 클라이언트에 의존적인 필드가 있으면 안됨
+- 특정 클라이언트가 값을 변경할 수 있는 필드가 있으면 안됨
+- 가급적 읽기만 가능해야 함
+- 필드 대신에 자바에서 공유되지 않는, 지역변수, 파라미터, ThreadLocal 등을 사용해야 함
+- 스프링 빈의 필드에 공유 값을 설정하면 큰 장애가 발생할 수 있음
+
+---
+
+## @Configuration
+
+```java
+@Configuration // 스프링에서는 설정정보에 @Configuration을 적어주게 되있음
+public class AppConfig {
+
+    @Bean   // 각 메소드에 @Bean을 적으면 스프링 컨테이너에 등록됨
+    public MemberService memberService() {
+        System.out.println("call AppConfig memberService");
+        return new MemberServiceImpl(memberRepository());
+    }
+
+    @Bean
+    public MemoryMemberRepository memberRepository() {
+        System.out.println("call AppConfig memberRepository");
+        return new MemoryMemberRepository();
+    }
+
+    @Bean
+    public OrderService orderService() {
+        System.out.println("call AppConfig orderService");
+        return new OrderServiceImpl(memberRepository(), discountPolicy());
+    }
+
+    @Bean
+    public DiscountPolicy discountPolicy() {
+        return new RateDiscountPolicy();
+    }
+}
+```
+
+위 코드에서 memberRepository는 3번 호출되어 싱글톤이 깨져야한다.
+
+비밀은 @Configuration 어노테이션에 있다.
+
+```java
+@Test
+void configurationDeep(){
+    ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+    AppConfig bean = ac.getBean(AppConfig.class);
+
+    System.out.println("bean = " + bean.getClass());
+}
+```
+
+을 실행해보면 결과로
+
+```
+bean = class hello.core.AppConfig$$SpringCGLIB$$0
+```
+
+이 출력된다.
+
+클래스 명 뒤에 `XXXCGLIB` 가 붙는다.
+
+이는 스프링 빈으로 내가 만든게 아닌 `CGLIB`라는 바이트코드를 조작하는 라이브러리를 사용하여 다른 클래스를 만들고, 만든 클래스를 스프링 빈으로 등록한 것이다.
+
+이렇게 만들어진 임의의 클래스가 싱글톤이 보장되도록 만들어준다.
+
+@Bean이 붙은 메서드마다 이미 스프링 빈이 존재하면 존재하는 빈을 반환하고, 스프링 빈이 없으면 생성해서 스프링 빈으로 등록하고 반환하는 코드가 동적으로 만들어진다.
+
+그렇다면 @Configuration없이 @Bean만 있다면 어떻게 될까?
+
+@Configuration이 없으면 스프링 빈에 등록은 되지만 팩토리 함수가 여러번 호출되어 싱글톤이 꺠질 수 있다.

--- a/스프링_핵심_원리_기본편/Section6_컴포넌트_스캔/김보현.md
+++ b/스프링_핵심_원리_기본편/Section6_컴포넌트_스캔/김보현.md
@@ -1,0 +1,120 @@
+## 컴포넌트 스캔
+
+앞선 예제에서 스프링 빈을 등록할 때 @bean annotation혹은 XML에 <bean>을 통해서 진행하였다.
+
+만약 스프링 빈이 많아지면 일일이 등록하기 귀찮아지고 누락이 발생할 수 있다.
+
+스프링은 설정 정보가 없어도 자동으로 스프링 빈을 등록하는 컴포넌트 스캔이라는 기능을 제공해준다.
+
+의존관계 주입도 자동으로 해주는 @autowired라는 기능도 제공해준다.
+
+컴포넌트 스캔을 사용하려면 @ComponentScan 어노테이션을 설정 클래스에 달아준다.
+
+컴포넌트 스캔은 @Component annotation이 붙은 클래스를 찾아가지고 자동으로 스프링 빈으로 등록해준다.
+
+### excludeFilters
+
+```java
+@ComponentScan(
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
+)
+```
+
+다음과 같이 제외할 클래스를 지정할 수 있다.
+
+### Autowired
+
+기존 설정 클래스에서 수동으로 빈을 등록해줄때는 의존성을 명시적으로 주입해줄 수 있었다.
+
+하지만 @Component 어노테이션을 붙여 컴포넌트 스캔을 사용한 스프링 빈 등록 방식은 우리가 명시적으로 의존성을 주입해줄 수 없다.
+
+@Autowired annotation을 생성자에 붙이면 스프링이 자동으로 의존성을 주입해준다.
+
+## 탐색 위치와 기본 스캔 대상
+
+```java
+@ComponentScan(basePackages = "hello.core")
+```
+
+컴포넌트 스캔에는 기본 탐색 패키지를 지정할 수 있다.
+
+기본 패키지를 지정하면 그 위치부터 탐색을 들어간다.
+
+```java
+@ComponentScan(basePackages = {"hello.core", "hello.service"})
+```
+
+위에 처럼 여러 기본 탐색 패키지를 지정할 수 있다.
+
+혹은 클래스를 지정할 수도 있다.
+
+```
+@ComponentScan(basePackageClasses = AutoAppConfig.class)
+```
+
+이렇게 작성하면 AutoAppConfig 클래스의 패키지가 기본 탐색 위치가 된다.
+
+탐색위치를 지정하지 않으면 @ComponentScan annotation이 붙은 위치를 기본 탐색 위치로 한다.
+
+권장하는 방법은 설정 정보 클래스를 프로젝트 최상단에 두는 것이다.
+
+스프링부트는 컴포넌트 스캔이 기본으로 들어가있다.
+
+## 컴포넌트 스캔 기본 대상
+
+아래의 Annotation이 붙은 클래스는 컴포넌트 스캔의 대상에 포함된다.
+
+- @Component
+- @Controller
+- @Service
+- @Repository
+- @Configuration
+
+왜냐하면 @Component annotation을 제외한 annotation을 열어보면 @Component annotation이 포함되어 있다.
+
+#### @Controller
+
+스프링 MVC 컨트롤러로 인식한다.
+
+#### @Repository
+
+스프링 데이터 접근 계층으로 인식하고, 데이터 계층의 예외를 스프링 예외로 변환해준다.
+
+#### @Configuration
+
+스프링 설정 정보를 인식하고, 스프링 빈이 싱글톤을 유지하도록 추가 처리를 한다.
+
+#### @Service
+
+특별할 처리를 하지 않는다. 개발자들이 **핵심 비즈니스 로직이 여기에 있겠구나라고 비즈니스 계층을 인식하는데 도움이 된다**.
+
+> 단, annotation에는 상속관계가 없고 한 annotation이 다른 annotation을 들고 있다고 해서 연동이 되지 않는다.
+> annotation이 특정 annotation을 들고 있다고 인식하는 것은 java에서 지원하는 기능이 아닌 spring에서 지원하는 기능이다.
+
+## 필터
+
+> FilterType에는 5가지 옵션이 있다.
+
+- FilterType.ANNOTATION - 기본값, 어노테이션을 인식해서 동작한다.
+- ASSIGNABLE_TYPE - 지정한 타입과 자식 타입을 인식해서 동작한다.
+- ASPECTJ - AspectJ 패턴을 사용
+- REGEX - 정규 표현식
+- CUSTOM - TypeFilter라는 인터페이스를 구현하여 조건을 직접 만들 수 있다.
+
+## 중복등록과 충돌
+
+> 빈이 중복으로 등록 되면 충돌이 일어날 수 있다.
+
+### 자동 빈 등록 vs 자동 빈 등록
+
+컴포넌트 스캔에 의해 자동으로 빈이 등록될때, 이름이 같은 경우 스프링 빈은 오류를 발생시킨다.
+
+- ConflictBeanDefinitionException 예외를 발생시킨다.
+
+### 수동 빈 등록 vs 자동 빈 등록
+
+수동으로 등록한 빈 이름과 자동으로 등록한 빈 이름이 중복될 경우 수동등록빈이 우선권을 가진다.
+
+같은 이름이 있을경우 수동 빈이 자동 빈을 오버라이딩 한다.
+
+최근에 SpringBoot는 자동빈과 수동빈이 중복될 경우 오류를 발생시킨다.


### PR DESCRIPTION
## 💿 학습 강좌명

[스프링 핵심 원리 기본편](https://www.inflearn.com/course/%EC%8A%A4%ED%94%84%EB%A7%81-%ED%95%B5%EC%8B%AC-%EC%9B%90%EB%A6%AC-%EA%B8%B0%EB%B3%B8%ED%8E%B8)

## 🗃️ 학습범위

- [x]  섹션4 - 스프링 컨테이너 생성
- [x]  섹션5 - 싱글톤 컨테이너
- [x]  섹션6 - 컴포넌트 스캔과 의존관계 자동주입

## 📆 학습날짜

2024-02-12 ~ 2024-02-25

## 📍 핵심
#### 스프링 컨테이너
> `ApplicationContext`를 스프링 컨테이너라고 한다.   


스프링 컨테이너는 Annotation을 사용해서 만들수도 있고 XML기반으로 만들 수도 있다.   
스프링 컨테이너는 Annotation으로 작성된 설정정보 또는 XML로 작성된 설정정보를 참고하여 의존관계를 주입한다.

---

#### 싱글톤 컨테이너
> 웹 어플리케이션은 여러 고객이 동시에 요청한다. 고객이 요청할때마다 새로운 객체를 생성하면 낭비가 심하니 싱글톤 패턴을 사용한다.   

스프링 컨테이너를 사용하면 기본적으로 객체를 싱글톤으로 만들어서 관리해준다.

중요한점 : 싱글톤은 여러 클라이언트가 하나의 객체 인스턴스를 공유하기에 Stateful하게 설계하면 안된다.

---

#### 컴포넌트 스캔
> 스프링 빈이 많아지면 @bean annotation을 사용하거나 XML을 사용해 등록하기 어렵고, 누락이 발생할 수 있다.   

이를 위해 자동으로 스프링 빈을 등록해주는 `@ComponentScan`이 등장하였다.

컴포넌트 스캔을 사용하려면 @ComponentScan 어노테이션을 설정 클래스에 달아준다.

##### Autowired
기존에 수동으로 빈을 등록해줄때는 의존성을 명시적으로 주입해줄 수 있었다.
하지만 컴포넌트 스캔을 사용하면 명시적으로 주입해줄 수 없는데, 이때 생성자에 `@Autowired` annotation을 붙여주면 스프링이 자동으로 의존성을 주입해준다.

## 🖋️ 느낀점
이번주에 밀린 강의 + 이번주차 강의까지 듣겠다고 했는데 못들었습니다...🥲빠른 시일내에 따라가도록 노력하겠습니다. 🙏

## 📚 Reference

참조할 자료가 있으면 첨부해주세요!
