### PR TITLE
docs: 스프링 핵심원리 기본편 Section9 내용정리

### DIFF
--- a/스프링_핵심_원리_기본편/Section9_빈스코프/김보현.md
+++ b/스프링_핵심_원리_기본편/Section9_빈스코프/김보현.md
@@ -1,0 +1,187 @@
+# 빈 스코프
+
+> 빈 스코프는 빈이 존재할 수 있는 범위를 뜻한다.
+
+## 스프링 빈의 스코프
+
+> 스프링은 다양한 스코프를 지원한다.
+
+- 싱글톤 : 기본 스코프, 스프링 컨테이너의 시작과 종료까지 유지되는 가장 넒은 범위의 스코프
+
+- 프로토타입 : 프로토타입 **빈의 생성과 의존관계 주입까지만** 관여하고 더는 관리하지 않는 매우 짧은 범위의 스코프
+
+- 웹 관련 스코프
+  - request : 웹 요청이 **들어오고 나갈때 까지** 유지되는 스코프
+  - session : **웹 세션이 생성되고 종료**될 때 까지 유지되는 스코프
+  - application : 웹의 서블릿 컨텍스트와 같은 범위로 유지되는 스코프
+
+## 스코프 지정방법
+
+### 컴포넌트 스캔 자동 등록
+
+```java
+@Scope("prototype")
+@Component
+public class HelloBean{}
+```
+
+### 수동 등록
+
+```java
+@Scope("prototype")
+@Bean
+PrototypeBean HelloBean(){
+  return new HelloBean();
+}
+```
+
+## 프로토타입 스코프
+
+> 스프링 컨테이너는 프로토타입 빈을 생성하고, 의존관계를 주입하고, 초기화까지만 처리한다.
+
+스프링 컨테이너에 조회하면 스프링 컨테이너는 항상 새로운 인스턴스를 생성해서 반환한다.
+
+클라이언트가 프로토타입 빈을 요청하면 새로운 프로토타입 빈을 생성하고 필요한 의존관계를 주입해서 반환한다.
+
+이후 스프링 컨테이너는 생성된 프로토타입 빈을 관리하지 않는다.
+
+**프로토타입 빈을 관리할 책임은 프로토타입 빈을 받은 클라이언트에 있다.**
+
+**`@PreDestroy`같은 종료 메서드는 호출되지 않는다.**
+
+### 싱글톤 빈과 함께 사용시 문제점
+
+싱글톤 빈이 프로토타입 빈을 사용하면 싱글톤 빈은 생성 시점에만 의존관계 주입을 받기 때문에 프로토타입 빈이 새로 생성되기는 하지만 싱글톤 빈과 함께 계속 유지된다.
+
+=> Provider를 사용해서 새로운 프로토타입 빈을 생성할 수 있다.
+
+### Provider
+
+> 필요한 의존관계를 찾는 기능인 **DL(Denpendency Lookup)**을 제공한다.
+
+```java
+@Scope("singleton")
+static class ClientBean {
+
+    @Autowired
+    private ObjectProvider<PrototypeBean> prototypeBeanProvider;
+
+    public int logic() {
+        PrototypeBean prototypeBean = prototypeBeanProvider.getObject();
+        prototypeBean.addCount();
+        int count = prototypeBean.getCount();
+        return count;
+    }
+}
+```
+
+prototypeBeanProvider.getObject()를 통해서 항상 새로운 프로토타입 빈이 생성되는 것을 확인할 수 있다.
+
+Provider는 새로운 prototype bean을 생성하는 것이 목적이 아닌 스프링컨테이너에서 직접조회하는 대신 조회를 해주는 대리자라고 이해할 수 있다.
+
+#### ObjectFactory vs ObjectProvider
+
+ObjectFactory에 기능을 추가한 것이 ObjectProvider이다.
+
+### JSR-330 Provider
+
+> 스프링에 의존하지 않는 방법, `javax.inject.Provider`라는 JSR-330 자바 표준을 사용하는 방법
+
+이 방법을 사용하려면 `java.inject:javax.inject:1`라이브러리를 gradle에 추가해야 한다.
+
+```java
+@Scope("singleton")
+static class ClientBean {
+
+  @Autowired
+  private Provider<PrototypeBean> prototypeBeanProvider;
+
+  public int logic() {
+      PrototypeBean prototypeBean = prototypeBeanProvider.get();
+      prototypeBean.addCount();
+      int count = prototypeBean.getCount();
+      return count;
+  }
+}
+```
+
+- 자바 표준이기 때문에 스프링이 아닌 다른 컨테이너도 사용할 수 있다.
+- 별도의 라이브러리가 필요하다.
+- `get()` 메서드 하나로 기능이 매우 단순하다.
+
+## 웹 스코프
+
+> 웹 환경에서만 동작하는 스코프
+
+프로토타입 스코프와 다르게 스프링이 종료시점까지 관리한다.
+
+- request : HTTP 요청 하나가 들어오고 나갈 때 까지 유지되는 스코프, 각각의 HTTP 요청마다 별도의 인스턴스 생성
+- session : HTTP Session과 동일한 생명주기를 가지는 스코프
+- application : 서블릿 컨텍스트(`ServletContext`)와 동일한 생명주기를 가지는 스코프
+- websocket : 웹 소켓과 동일한 생명주기를 가지는 스코프
+
+### Request 스코프
+
+웹 스코프는 웹 환경에서만 동작하므로 web환경이 동작하도록 라이브러리를 추가해야한다.
+
+`org.springframework.boot:spring-boot-starter-web`을 추가해준다.
+
+웹 라이브러리가 없으면 `AnnotationConfigApplicationContext`를 기반으로 어플리케이션이 구동된다.
+웹 라이브러리를 추가하면 `AnnotationConfigServletServeltWebServerApplicationContext`를 기반으로 어플리케이션을 구동한다.
+
+`request`스코프 빈을 컨테이너 생성시점에 의존관계로 주입하면 에러가 발생한다.
+
+`request`스코프는 HTTP 요청을 들어올때 생성되기때문에 컨테이너 생성시점에는 빈이 생성되지 않는다.
+
+이를 해결할 수 있는 방법은 2가지가 있다.
+
+#### 1.Provider
+
+```java
+@Controller
+@RequiredArgsConstructor
+public class LogDemoController {
+    private final LogDemoService logDemoService;
+    private final ObjectProvider<MyLogger> myLoggerProvider;
+
+    @RequestMapping("log-demo")
+    @ResponseBody
+    public String logDemo(HttpServletRequest request){
+        String requestURL = request.getRequestURI().toString();
+        MyLogger myLogger = myLoggerProvider.getObject();
+        myLogger.setRequestUrl(requestURL);
+
+        myLogger.log("controller test");
+        logDemoService.logic("testId");
+        return "OK";
+    }
+}
+
+```
+
+#### 2. Proxy
+
+> CGLIB이라는 라이브러리로 내 클래스를 상속받은 가짜 프록시 객체를 만들어서 주입해준다.
+
+적용 대상이 클래스면 `ScopedProxyMode.TARGET_CLASS`, 인터페이스면
+
+`ScopedProxyMode.INTERFACES`를 선택한다.
+
+```java
+@Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class MyLogger {
+    private String uuid;8
+    private String requestUrl;
+...
+```
+
+스프링 컨테이너에 myLogger라는 이름으로 진짜 대신에 이 가짜 프록시 객체를 등록한다.
+
+가짜 프록시 객체는 요청이 오면 그때 내부에서 진짜 빈을 요청하는 위임 로직이 들어있다.
+
+가짜 프록시 객체는 단순한 위임 로직만 있고 싱글톤처럼 동작한다.
+
+**핵심은 진짜 객체 조회를 꼭 필요한 시점까지 지연처리하는 것이다.**
+
+**어노테이션 설정 변경만으로 원본 객체를 프록시 객체로 대체할 수 있는것이 DI 컨테이너가 가진 장점이다.**


### PR DESCRIPTION
## 💿 학습 강좌명

[스프링 핵심 원리 기본편](https://www.inflearn.com/course/%EC%8A%A4%ED%94%84%EB%A7%81-%ED%95%B5%EC%8B%AC-%EC%9B%90%EB%A6%AC-%EA%B8%B0%EB%B3%B8%ED%8E%B8)

## 🗃️ 학습범위

- [x]  섹션9 - 빈 스코프

## 📆 학습날짜

2024-03-11 ~ 2024-03-17

## 📍 핵심

스프링의 스코프
1. 싱글톤 - 컨테이너의 시작과 종료까지 유지
2. 프로토타입 - 빈의 생성과 의존관계 주입까지만 관여, 이후에는 스프링 컨테이너가 관리하지 않음
3. 웹관련 스코프(request, session, application, websocket)

## 🖋️ 느낀점
프로그래밍언어에서의 블록스코프나 함수스코프와 다른, 스프링 프레임워크에서의 스코프 개념을 새로 배울 수 있었습니다.
또 어노테이션 변경만으로 복잡한 일을 간단하게 처리할 수 있는 스프링의 장점을 느낄 수 있었습니다.

## 📚 Reference

참조할 자료가 있으면 첨부해주세요!
